### PR TITLE
Expose execute_with_pipes and the needed functions.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod parser;
 
 #[cfg(feature = "shell")]
-mod shell;
+pub mod shell;
 
 #[cfg(feature = "shell")]
 pub use shell::*;

--- a/src/shell/test_builder.rs
+++ b/src/shell/test_builder.rs
@@ -7,16 +7,13 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 use std::rc::Rc;
-use tokio::task::JoinHandle;
 
-use crate::execute_with_pipes;
 use crate::parser::parse;
 use crate::shell::fs_util;
-use crate::shell::types::pipe;
-use crate::shell::types::ShellPipeWriter;
 use crate::shell::types::ShellState;
 use crate::ShellCommand;
 use crate::ShellCommandContext;
+use crate::{execute_with_pipes, get_output_writer_and_handle, pipe};
 
 use super::types::ExecuteResult;
 
@@ -276,14 +273,4 @@ impl TestBuilder {
       }
     }
   }
-}
-
-fn get_output_writer_and_handle() -> (ShellPipeWriter, JoinHandle<String>) {
-  let (stdout_reader, stdout_writer) = pipe();
-  let stdout_handle = tokio::task::spawn_blocking(|| {
-    let mut buf = Vec::new();
-    stdout_reader.pipe_to(&mut buf).unwrap();
-    String::from_utf8_lossy(&buf).to_string()
-  });
-  (stdout_writer, stdout_handle)
 }

--- a/src/shell/types.rs
+++ b/src/shell/types.rs
@@ -193,7 +193,7 @@ impl ExecuteResult {
 }
 
 /// Reader side of a pipe.
-pub struct ShellPipeReader(os_pipe::PipeReader);
+pub struct ShellPipeReader(pub os_pipe::PipeReader);
 
 impl Clone for ShellPipeReader {
   fn clone(&self) -> Self {
@@ -345,10 +345,4 @@ impl ShellPipeWriter {
     let bytes = format!("{line}\n");
     self.write_all(bytes.as_bytes())
   }
-}
-
-/// Used to communicate between commands.
-pub fn pipe() -> (ShellPipeReader, ShellPipeWriter) {
-  let (reader, writer) = os_pipe::pipe().unwrap();
-  (ShellPipeReader(reader), ShellPipeWriter::OsPipe(writer))
 }


### PR DESCRIPTION
PR description on the denoland pr:

As requested in #86 we want to use the `deno_task_shell` in the same way as `deno` does.
We would like to run tests as the `test_builder` is doing for this project.

This PR makes `execute_with_pipes` a public function and the necessary functions to run the tests with that as well. 
I also tried to add some documentation, please check if I interpreted the code correctly. 

To see what we did with it check out this PR: https://github.com/prefix-dev/pixi/pull/173

Thanks for making this a library! 

Closes #86 